### PR TITLE
Favorited sellers by customer

### DIFF
--- a/bangazon.session.sql
+++ b/bangazon.session.sql
@@ -1,0 +1,16 @@
+SELECT
+    f.id,
+    f.customer_id,
+    f.seller_id,
+    c.phone_number,
+    c.address,
+    u.id user_id,
+    u.username,
+    u.first_name || ' ' || u.last_name AS full_name,
+    u.email
+FROM
+    bangazonapi_favorite f
+JOIN
+    bangazonapi_customer c ON c.id = f.customer_id
+JOIN
+    auth_user u ON c.user_id = u.id

--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'bangazonapi',
     'safedelete',
+    'bangazonreports',
 ]
 
 REST_FRAMEWORK = {

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     url(r'^login$', login_user),
     url(r'^api-token-auth$', obtain_auth_token),
     url(r'^api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'', include('bangazonreports.urls'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/fixtures/favoritesellers.json
+++ b/bangazonapi/fixtures/favoritesellers.json
@@ -1,26 +1,26 @@
 [
-    {
-        "pk": 1,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "seller_id": 5
-        }
-    },
-    {
-        "pk": 2,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "seller_id": 6
-        }
-    },
-    {
-        "pk": 3,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "seller_id": 7
-        }
+  {
+    "pk": 1,
+    "model": "bangazonapi.favorite",
+    "fields": {
+      "customer_id": 7,
+      "seller_id": 5
     }
+  },
+  {
+    "pk": 2,
+    "model": "bangazonapi.favorite",
+    "fields": {
+      "customer_id": 7,
+      "seller_id": 6
+    }
+  },
+  {
+    "pk": 3,
+    "model": "bangazonapi.favorite",
+    "fields": {
+      "customer_id": 7,
+      "seller_id": 7
+    }
+  }
 ]

--- a/bangazonreports/admin.py
+++ b/bangazonreports/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/bangazonreports/apps.py
+++ b/bangazonreports/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class BangazonreportsConfig(AppConfig):
+    name = 'bangazonreports'

--- a/bangazonreports/templates/users/favorited_sellers_by_customer.html
+++ b/bangazonreports/templates/users/favorited_sellers_by_customer.html
@@ -1,0 +1,20 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Customer Favorites</h1>
+
+    {% for user in user_favorite_list %}
+    <h2>{{ user.full_name }}</h2>
+    <ol>
+      {% for favorite in user.favorites %}
+      <li>Favorite Seller: {{ favorite.seller.user }}</li>
+      {% endfor %}
+    </ol>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazonreports/tests.py
+++ b/bangazonreports/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,0 +1,7 @@
+
+from django.urls import path
+from .views import user_favorite_list
+
+urlpatterns = [
+    path('reports/userfavorites', user_favorite_list),
+]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,0 +1,2 @@
+from .connection import Connection
+from .users.favbyuser import user_favorite_list

--- a/bangazonreports/views/connection.py
+++ b/bangazonreports/views/connection.py
@@ -1,0 +1,2 @@
+class Connection:
+    db_path = "/Users/calebwagner/workspace/bangazon-calebwagner/db.sqlite3"

--- a/bangazonreports/views/users/favbyuser.py
+++ b/bangazonreports/views/users/favbyuser.py
@@ -1,0 +1,61 @@
+import sqlite3
+from django.shortcuts import render
+from bangazonapi.models import Favorite
+from bangazonreports.views import Connection
+
+def user_favorite_list(request):
+    """[summary]
+
+    Args:
+        request ([type]): [description]
+    """
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute("""
+                SELECT
+                    f.id,
+                    f.customer_id,
+                    f.seller_id,
+                    c.phone_number,
+                    c.address,
+                    u.id user_id,
+                    u.username,
+                    u.first_name || ' ' || u.last_name AS full_name,
+                    u.email
+                FROM
+                    bangazonapi_favorite f
+                JOIN
+                    bangazonapi_customer c ON c.id = f.customer_id
+                JOIN
+                    auth_user u ON c.user_id = u.id
+            """)
+
+            database = db_cursor.fetchall()
+
+            favorites_by_user = {}
+
+            for row in database:
+                favorite = Favorite()
+                favorite.customer_id = row["customer_id"]
+                favorite.seller_id = row["seller_id"]
+
+                uid = row["user_id"]
+
+                if uid in favorites_by_user:
+                    favorites_by_user[uid]['favorites'].append(favorite)
+
+                else:
+                    favorites_by_user[uid] = {}
+                    favorites_by_user[uid]["id"] = uid
+                    favorites_by_user[uid]["full_name"] = row["full_name"]
+                    favorites_by_user[uid]["favorites"] = [favorite]
+
+    list_of_users_with_favorites = favorites_by_user.values()
+
+    template = 'users/favorited_sellers_by_customer.html'
+    context = {'user_favorite_list': list_of_users_with_favorites}
+
+    return render(request, template, context)


### PR DESCRIPTION
This thicket shows a HTML report showing all users that have favorited a seller, including the favorited sellers.
## Changes
- Created `bangazonreports/views/users/favbyuser.py` file that handles logic for displaying reports 
- Created `bangazonreports/templates/users/favorited_sellers_by_customer.html ` to display HTML report

## Response

GET `/reports/userfavorites` 

```json
[
  {
    "pk": 1,
    "model": "bangazonapi.favorite",
    "fields": {
      "customer_id": 7,
      "seller_id": 5
    }
  },
  {
    "pk": 2,
    "model": "bangazonapi.favorite",
    "fields": {
      "customer_id": 7,
      "seller_id": 6
    }
  },
  {
    "pk": 3,
    "model": "bangazonapi.favorite",
    "fields": {
      "customer_id": 7,
      "seller_id": 7
    }
  }
]

```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run the server
- [ ] in the URL paste in `http://localhost:8000/reports/userfavorites`
- [ ] User `Brenda Long` will appear and 3 favorite sellers will appear below


## Related Issues
- Fixes #2