### PR TITLE
incomplete orders report

### DIFF
--- a/bangazon.session.sql
+++ b/bangazon.session.sql
@@ -1,16 +1,124 @@
+-- SELECT
+--     f.id,
+--     f.customer_id,
+--     f.seller_id,
+--     c.phone_number,
+--     c.address,
+--     u.id user_id,
+--     u.username,
+--     u.first_name || ' ' || u.last_name AS full_name,
+--     u.email
+-- FROM
+--     bangazonapi_favorite f
+-- JOIN
+--     bangazonapi_customer c ON c.id = f.customer_id
+-- JOIN
+--     auth_user u ON c.user_id = u.id
+
+-- SELECT
+--     o.id,
+--     o.payment_type_id,
+--     o.customer_id,
+--     u.id user_id,
+--     u.username,
+--     u.first_name || ' ' || u.last_name AS full_name
+-- FROM bangazonapi_order o
+-- JOIN bangazonapi_customer c ON c.id = o.customer_id
+-- JOIN auth_user u ON c.user_id = u.id
+
+
+-- SELECT
+--     o.id order_id,
+--     SUM(p.price) AS total_price,
+--     p.
+--     u.id user_id,
+--     u.username,
+--     u.first_name || ' ' || u.last_name AS full_name
+-- FROM bangazonapi_order o
+-- JOIN bangazonapi_product p ON c.id = o.customer_id
+-- JOIN auth_user u ON c.user_id = u.id
+
+-- SELECT
+-- o.id,
+-- u.first_name || ' ' || u.last_name AS full_name,
+-- sum(p.price) AS order_total,
+-- count(op.id) AS num_items
+-- FROM
+--     bangazonapi_order AS o
+-- JOIN
+--     bangazonapi_customer AS c ON c.id = o.customer_id
+-- JOIN
+--     auth_user AS u ON u.id = c.user_id
+-- JOIN LEFT
+--     bangazonapi_orderproduct AS op ON op.order_id = o.id
+-- JOIN
+--     LEFT bangazonapi_product AS p ON op.product_id = p.id
+--     WHERE o.payment_type_id NOTNULL
+--     GROUP BY o.id
+
+-- SELECT
+--     o.id,
+--     u.first_name || ' ' || u.last_name AS full_name,
+--     sum(p.price) AS order_total,
+--     count(op.id) AS num_items
+-- FROM bangazonapi_order AS o
+-- JOIN bangazonapi_customer AS c ON c.id = o.customer_id
+-- JOIN auth_user AS u ON u.id = c.user_id
+-- LEFT JOIN bangazonapi_orderproduct AS op ON op.order_id = o.id
+-- LEFT JOIN bangazonapi_product AS p ON op.product_id = p.id
+-- WHERE o.payment_type_id NOTNULL
+-- GROUP BY o.id
+
+
+-- SELECT
+--     o.id,
+--     u.first_name || ' ' || u.last_name AS customer_name,
+--     sum(p.price) AS order_total
+-- FROM bangazonapi_order AS o
+-- JOIN bangazonapi_orderproduct AS op ON op.order_id = o.id
+-- JOIN bangazonapi_product AS p ON op.product_id = p.id
+-- JOIN auth_user AS u ON u.id = o.customer_id
+-- WHERE o.payment_type_id IS NOT NULL
+-- GROUP BY o.id
+
+                -- SELECT
+                -- bangazonapi_order.id AS order_id,
+                -- SUM(bangazonapi_product.price) AS total_price,
+                -- auth_user.first_name || " " || auth_user.last_name AS customer_name
+                -- FROM bangazonapi_Order
+
+                -- JOIN bangazonapi_OrderProduct
+
+                -- ON bangazonapi_OrderProduct.order_id = bangazonapi_order.id
+
+
+                -- JOIN bangazonapi_Product
+                -- ON bangazonapi_Product.id = bangazonapi_OrderProduct.product_id
+
+                -- JOIN auth_user
+                -- ON auth_user.id = bangazonapi_Order.customer_id
+                -- WHERE bangazonapi_order.payment_type_id IS NULL
+                -- GROUP BY bangazonapi_order.id
+
+
 SELECT
-    f.id,
-    f.customer_id,
-    f.seller_id,
-    c.phone_number,
-    c.address,
-    u.id user_id,
-    u.username,
-    u.first_name || ' ' || u.last_name AS full_name,
-    u.email
-FROM
-    bangazonapi_favorite f
-JOIN
-    bangazonapi_customer c ON c.id = f.customer_id
-JOIN
-    auth_user u ON c.user_id = u.id
+-- I want to secect the orderId, total balance of order, and users name
+    bangazonapi_order.id AS order_id,
+    SUM(bangazonapi_product.price) AS order_total,
+    auth_user.first_name || " " || auth_user.last_name AS customer_name
+-- from the orders table, I want you to ...
+FROM bangazonapi_order
+-- join the order and order_product tables
+JOIN bangazonapi_orderproduct
+-- "ON" shows the connection between tables so ...
+-- connect the order_product table with the property order_id ...
+-- to the id of the orders table
+    ON bangazonapi_orderproduct.order_id = bangazonapi_order.id
+-- now join the product table to order_product column
+JOIN bangazonapi_product
+-- ... by the connection
+    ON bangazonapi_product.id = bangazonapi_orderproduct.product_id
+JOIN auth_user
+    ON auth_user.id = bangazonapi_order.customer_id
+WHERE bangazonapi_order.payment_type_id IS NULL
+GROUP BY bangazonapi_order.id

--- a/bangazonreports/templates/orders/incompleteorders.html
+++ b/bangazonreports/templates/orders/incompleteorders.html
@@ -1,0 +1,17 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Incomplete Orders</h1>
+
+    {% for order in incomplete_orders_list %}
+    <h2>OrderId: {{ order.order_id }}</h2>
+    <div>Customer: {{order.customer_name}}</div>
+    <div>Receipt: ${{order.order_total}}</div>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,7 +1,8 @@
 
 from django.urls import path
-from .views import user_favorite_list
+from .views import user_favorite_list, incomplete_orders_list
 
 urlpatterns = [
     path('reports/userfavorites', user_favorite_list),
+    path('reports/incompleteorders', incomplete_orders_list),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,2 +1,3 @@
 from .connection import Connection
 from .users.favbyuser import user_favorite_list
+from .orders.incompleteorders import incomplete_orders_list

--- a/bangazonreports/views/orders/incompleteorders.py
+++ b/bangazonreports/views/orders/incompleteorders.py
@@ -1,0 +1,51 @@
+import sqlite3
+from django.shortcuts import render
+# from bangazonapi.models import Order
+from bangazonreports.views import Connection
+
+def incomplete_orders_list(request):
+    """[summary]
+
+    Args:
+        request ([type]): [description]
+    """
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute("""
+            SELECT
+            bangazonapi_order.id AS order_id,
+            SUM(bangazonapi_product.price) AS order_total,
+            auth_user.first_name || " " || auth_user.last_name AS customer_name
+            FROM bangazonapi_order
+            JOIN bangazonapi_orderproduct
+            ON bangazonapi_orderproduct.order_id = bangazonapi_order.id
+            JOIN bangazonapi_product
+            ON bangazonapi_product.id = bangazonapi_orderproduct.product_id
+            JOIN auth_user
+            ON auth_user.id = bangazonapi_order.customer_id
+            WHERE bangazonapi_order.payment_type_id IS NULL
+            GROUP BY bangazonapi_order.id
+            """)
+
+            database = db_cursor.fetchall()
+
+            incomplete_orders = {}
+
+            for row in database:
+                uid = row["order_id"]
+
+                incomplete_orders[uid] = {}
+                incomplete_orders[uid]["order_id"] = uid
+                incomplete_orders[uid]["customer_name"] = row["customer_name"]
+                incomplete_orders[uid]["order_total"] = row["order_total"]
+
+
+    list_of_incomplete_orders = incomplete_orders.values()
+
+    template = 'orders/incompleteorders.html'
+    context = {'incomplete_orders_list': list_of_incomplete_orders}
+
+    return render(request, template, context)


### PR DESCRIPTION
Completed issue ticket #3 by showing incomplete orders report with html template.

## Changes
- Added folder and files `orders/incompleteorders.py` to include logic for report
- Added folder and files `orders/incompleteorders.html` that displays order report
- Modified file `bangazonreports/urls.py` to include URL path

1. Checkout this branch locally.
   ```
   git fetch --all
   git checkout cjw-reports-order
   ```

## Testing
- [ ] check for above additions to project
- [ ] Run `python3 manage.py runserver` in terminal
- [ ] in URL paste in `http://localhost:8000/reports/incompleteorders`
- [ ] a list of 3 customers with incomplete orders should appear

## Related Issues
- Fixes #3 